### PR TITLE
Add an auto-update action

### DIFF
--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -1,0 +1,76 @@
+name: Auto Update
+on:
+  # Manual trigger
+  workflow_dispatch:
+  # Check regularly the upstream every four hours
+  schedule:
+    - cron: "0 0,4,8,12,16,20 * * *"
+
+jobs:
+  check-upstream:
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{steps.check.outputs.release}}
+    steps:
+      # Get the latest release of traefik/traefik in format 'vX.X.X'
+      - id: latest-upstream
+        uses: pozetroninc/github-action-get-latest-release@v0.5.0
+        with:
+          repository: traefik/traefik
+          excludes: prerelease, draft
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - id: check
+        name: Check for new releases
+        run: |
+          LATEST="${{ steps.latest-upstream.outputs.release }}"
+          # Get the current version from the repo
+          CURRENT="v$(cat version)"
+
+          if [[ "$CURRENT" != "$LATEST" ]]; then
+            echo "::set-output name=release::${LATEST}"
+            echo "New upstream release '$LATEST' found"
+          else
+            echo "No new upstream release found"
+          fi
+
+  create-pr:
+    runs-on: ubuntu-latest
+    needs: check-upstream
+    if: ${{ needs.check-upstream.outputs.release != '' }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Update version
+        run: |
+          # Grab the output from the last job
+          LATEST="${{ needs.check-upstream.outputs.release }}"
+          # Get the current version from the repo
+          CURRENT="$(cat version)"
+          # Update the version (strip the leading 'v' from the LATEST version)
+          echo "${$LATEST/v/}" > version
+
+      # We use a Github App and token to allow Github Actions to run properly on the created PR.
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_KEY }}
+
+      - name: Create a PR for local changes
+        uses: peter-evans/create-pull-request@v4
+        id: cpr
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          commit-message: "Bump traefik version to ${{ needs.check-upstream.outputs.release }}"
+          committer: "Github Actions <github-actions@github.com>"
+          author: "Github Actions <github-actions@github.com>"
+          title: "Update to Traefik ${{ needs.check-upstream.outputs.release }}"
+          body: Automated update to follow upstream [release](https://github.com/traefik/traefik/releases/tag/${{ needs.check-upstream.outputs.release }}) of Traefik ${{ needs.check-upstream.outputs.release }}.
+          branch: "auto-${{ needs.check-upstream.outputs.release }}"
+          delete-branch: true
+          reviewers: jnsgruk
+          assignees: jnsgruk


### PR DESCRIPTION
Re-use the logic from the Terraform snap that queries the upstream
releases from Github and automatically creates a PR to update the
version of Traefik, tagging me for review.